### PR TITLE
if name doesnot exist, give ./ to it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ var global = opts.g || opts.global
 var pager = process.env.PAGER || opts.pager || 'less'
 
 if(!name) {
-    console.error('usage: readme packagename [-g]')
-    process.exit(1)
+    name = './'
   }
 
 if(resolve.isCore(name)) {


### PR DESCRIPTION
A most frequently usage for me was `readme ./` to see the readme file.
So how about to use `readme` instead of `readme ./`

BTW, this tool is better than `cat readme.md` or `vi README.md` or `cat readme.markdown | less` etc. Thanks a lot! : )
