### PR TITLE
Use npm prefix for resolving global modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var path    = require('path')
 var opts    = require('optimist').argv
 var toUrl   = require('github-url').toUrl
 var opener  = require('opener')
+var rc      = require('rc')
 
 var name = opts._.shift()
 var global = opts.g || opts.global
@@ -24,8 +25,9 @@ if(resolve.isCore(name)) {
 
 try {
   var found = false
+  var prefix = rc('npm').prefix || path.join(process.execPath, '../..')
   var file = resolve.sync(name, {
-    basedir: global ? path.join(process.execPath, '../../lib') : process.cwd(), 
+    basedir: global ? path.join(prefix, 'lib') : process.cwd(),
     packageFilter: function (pkg, dir) {
       if(opts.git || opts.github || opts.gh) {
         opener(toUrl(pkg.repository))

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "resolve": "~0.2.2",
     "optimist": "~0.3.5",
     "github-url": "~1.0.0",
-    "opener": "~1.3.0"
+    "opener": "~1.3.0",
+    "rc": "~1.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
`--global` switch does not seem to work if npm prefix is set up in `.npmrc`.

This PR fixes it.