### PR TITLE
Add docs for core libs

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var opts    = require('optimist').argv
 var toUrl   = require('github-url').toUrl
 var opener  = require('opener')
 var rc      = require('rc')
+var apidocs = require('node-api-docs')
 
 var name = opts._.shift()
 var global = opts.g || opts.global
@@ -17,9 +18,7 @@ if(!name) {
   }
 
 if(resolve.isCore(name)) {
-    console.error('detection of core libs not yet supported', name)
-    console.error('pull requests accepted.')
-    process.exit(1)
+    return apidocs(name).pipe(pager())
   }
 
 try {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "optimist": "~0.3.5",
     "default-pager": "~1.0.1",
     "github-url": "~1.0.0",
+    "node-api-docs": "~0.1.0",
     "opener": "~1.3.0",
     "rc": "~1.0.0"
   },

--- a/readme.markdown
+++ b/readme.markdown
@@ -4,7 +4,7 @@ Retrieve a node module's readme from the command line, and pipe it into `less`.
 
 ## Installation
 
-``` 
+```
 > npm install readme -g
 ```
 
@@ -20,6 +20,8 @@ readme resolves your module in the same way as `require()`
 > readme ./       # for the current module.
 
 > readme readme -g # for a globally installed module.
+
+> readme http       # for built-in module
 
 > readme readme --web # open the project's webpage
 


### PR DESCRIPTION
Readmes for core libs are downloaded from the Internet each time and won't work offline but it would still be convenient to have them here.