### PR TITLE
prepublish script to download all core docs for offline use

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
 node_modules
-core
+!core

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-!core

--- a/bin/download.js
+++ b/bin/download.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var apidocs = require('node-api-docs')
+var jsonstream = require('jsonstream')
+var through = require('through2')
+var marked = require('marked')
+var mkdirp = require('mkdirp')
+var fs = require('fs')
+var path = require('path')
+
+var coredir = path.join(__dirname, '../core')
+mkdirp.sync(coredir)
+
+apidocs.json('index')
+  .pipe(jsonstream.parse(['desc',true,'text']))
+  .pipe(through.obj(function (text, enc, next) {
+    var m = /^\[[^\]]+\]\((\S+)\.html\)$/.exec(text)
+    if (!m) return next()
+    var file = m[1] + '.md'
+    apidocs(m[1]).pipe(fs.createWriteStream(path.join(coredir, file)))
+    next()
+  }))

--- a/bin/download.js
+++ b/bin/download.js
@@ -3,7 +3,6 @@
 var apidocs = require('node-api-docs')
 var jsonstream = require('jsonstream')
 var through = require('through2')
-var marked = require('marked')
 var mkdirp = require('mkdirp')
 var fs = require('fs')
 var path = require('path')
@@ -16,6 +15,7 @@ apidocs.json('index')
   .pipe(through.obj(function (text, enc, next) {
     var m = /^\[[^\]]+\]\((\S+)\.html\)$/.exec(text)
     if (!m) return next()
+    if (m[1] === 'documentation' || m[1] === 'synopsis') return next()
     var file = m[1] + '.md'
     apidocs(m[1]).pipe(fs.createWriteStream(path.join(coredir, file)))
     next()

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ try {
   var name = String(opts._.shift() || '')
   var readme
 
-  if (opts.core || iscore(name)) {
+  if (opts.core) {
     readme = fs.createReadStream(path.join(coredir, name + '.md'))
   } else if (opts.github || opts.web) {
     var pkg = require(packageFile(name, opts))
@@ -126,11 +126,15 @@ try {
       try {
         pkgFile = packageFile(name, opts)
       } catch (e) {
-        // Rethrow the original error for more clear error message.
-        throw error
+        if (iscore(name)) {
+          readme = fs.createReadStream(path.join(coredir, name + '.md'))
+        } else {
+          // Rethrow the original error for more clear error message.
+          throw error
+        }
       }
     }
-    readme = packageReadme(path.dirname(pkgFile))
+    if (!readme) readme = packageReadme(path.dirname(pkgFile))
   } else {
     try {
       readme = packageReadme(path.dirname(currentPackageFile(opts)))

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var pagerSupportsColor = require('pager-supports-color')
 var path               = require('path')
 var through            = require('through2')
 var readmeFilenames    = require('readme-filenames')
+var iscore             = require('is-core-module')
 
 
 function usage() {
@@ -110,7 +111,7 @@ try {
   var name = String(opts._.shift() || '')
   var readme
 
-  if (opts.core) {
+  if (opts.core || iscore(name)) {
     readme = fs.createReadStream(path.join(coredir, name + '.md'))
   } else if (opts.github || opts.web) {
     var pkg = require(packageFile(name, opts))

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 // -*- js2-strict-missing-semi-warning: nil; -*-
 
-var apidocs            = require('node-api-docs')
 var concat             = require('concat-stream')
 var duplexer           = require('duplexer2')
 var findRoot           = require('find-root')
@@ -44,6 +43,7 @@ var basedir = function (opts) {
   return path.join(npmPrefix(), 'lib')
 }
 
+var coredir = path.join(__dirname, 'core')
 
 var packageFile = function (name, opts) {
   return resolve.sync(path.join(name, 'package.json'),
@@ -111,7 +111,7 @@ try {
   var readme
 
   if (opts.core) {
-    readme = apidocs(name)
+    readme = fs.createReadStream(path.join(coredir, name + '.md'))
   } else if (opts.github || opts.web) {
     var pkg = require(packageFile(name, opts))
     opener(packageUrl(pkg, opts.web))

--- a/package.json
+++ b/package.json
@@ -11,25 +11,22 @@
     "github-url": "~1.2.0",
     "help-version": "~0.2.0",
     "is-core-module": "~1.0.2",
+    "jsonstream": "~1.0.3",
     "marked": "~0.3.3",
     "marked-terminal": "~1.6.1",
     "minimist": "~1.1.1",
+    "mkdirp": "~0.5.1",
     "npm-prefix": "~1.1.0",
+    "node-api-docs": "~0.1.0",
     "opener": "~1.3.0",
     "pager-supports-color": "~0.1.0",
     "readme-filenames": "~1.0.0",
     "resolve": "~1.1.6",
     "through2": "~2.0.0"
   },
-  "devDependencies": {
-    "jsonstream": "~1.0.3",
-    "mkdirp": "~0.5.1",
-    "node-api-docs": "~0.1.0",
-    "through2": "~2.0.0"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "bin/download.js"
+    "postinstall": "bin/download.js"
   },
   "bin": {
     "readme": "./index.js"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "marked": "~0.3.3",
     "marked-terminal": "~1.6.1",
     "minimist": "~1.1.1",
-    "node-api-docs": "~0.1.0",
     "npm-prefix": "~1.1.0",
     "opener": "~1.3.0",
     "pager-supports-color": "~0.1.0",
@@ -21,9 +20,15 @@
     "resolve": "~1.1.6",
     "through2": "~2.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jsonstream": "~1.0.3",
+    "mkdirp": "~0.5.1",
+    "node-api-docs": "~0.1.0",
+    "through2": "~2.0.0"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "bin/download.js"
   },
   "bin": {
     "readme": "./index.js"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "find-root": "~0.1.1",
     "github-url": "~1.2.0",
     "help-version": "~0.2.0",
+    "is-core-module": "~1.0.2",
     "marked": "~0.3.3",
     "marked-terminal": "~1.6.1",
     "minimist": "~1.1.1",

--- a/readme.markdown
+++ b/readme.markdown
@@ -21,7 +21,7 @@ readme resolves your module in the same way as `require()`
 
 > readme readme -g # for a globally installed module.
 
-> readme http      # for a core module
+> readme -c http   # for a core module
 
 > readme readme --web # open the project's webpage
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -21,7 +21,7 @@ readme resolves your module in the same way as `require()`
 
 > readme readme -g # for a globally installed module.
 
-> readme http -c    # for a core module
+> readme http      # for a core module
 
 > readme readme --web # open the project's webpage
 


### PR DESCRIPTION
This change downloads the node core docs on prepublish and inlines them into the package for offline use. #14